### PR TITLE
fix: remove stdin for geth start command

### DIFF
--- a/src/main/geth.ts
+++ b/src/main/geth.ts
@@ -159,7 +159,7 @@ export const startGeth = async () => {
   }
   logger.info(execFileAbsolutePath);
   const options: SpawnOptions = {
-    stdio: ['inherit', 'pipe', 'pipe'],
+    stdio: [null, 'pipe', 'pipe'],
     detached: false,
   };
   const childProcess = spawn(execFileAbsolutePath, gethInput, options);


### PR DESCRIPTION
fix issue on Windows where a command prompt opens when geth is started