### PR TITLE
feat: Max peers config setting to lower bandwidth usage, added prysm config

### DIFF
--- a/src/common/NodeSpecs/besu/besu-v1.0.0.json
+++ b/src/common/NodeSpecs/besu/besu-v1.0.0.json
@@ -187,7 +187,7 @@
     "dataStorageFormat": {
       "displayName": "The data storage format to use",
       "category": "Storage",
-      "cliConfigPrefix": "--data-storage-format==",
+      "cliConfigPrefix": "--data-storage-format=",
       "uiControl": {
         "type": "select/single",
         "controlTranslations": [

--- a/src/common/NodeSpecs/besu/besu-v1.0.0.json
+++ b/src/common/NodeSpecs/besu/besu-v1.0.0.json
@@ -203,6 +203,15 @@
       },
       "defaultValue": "FOREST",
       "documentation": "https://besu.hyperledger.org/en/stable/Reference/CLI/CLI-Syntax/#data-storage-format"
+    },
+    "maxPeerCount": {
+      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "cliConfigPrefix": "--max-peers=",
+      "defaultValue": "25",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://besu.hyperledger.org/en/stable/HowTo/Find-and-Connect/Managing-Peers/#limit-peers"
     }
   },
   "documentation": {

--- a/src/common/NodeSpecs/geth/geth-v1.0.0.json
+++ b/src/common/NodeSpecs/geth/geth-v1.0.0.json
@@ -161,6 +161,23 @@
         "type": "text"
       },
       "documentation": "https://geth.ethereum.org/docs/rpc/server#websocket-server"
+    },
+    "lightModeMaxPeerCount": {
+      "displayName": "Light Mode Max Peer Count (set to low number to use less bandwidth)",
+      "cliConfigPrefix": "--light.maxpeers ",
+      "defaultValue": "100",
+      "uiControl": {
+        "type": "text"
+      }
+    },
+    "maxPeerCount": {
+      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "cliConfigPrefix": "--maxpeers ",
+      "defaultValue": "50",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://geth.ethereum.org/docs/interface/peer-to-peer#peer-limit"
     }
   },
   "iconUrl": "https://clientdiversity.org/assets/img/execution-clients/geth-logo.png"

--- a/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
+++ b/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
@@ -103,8 +103,8 @@
       "infoDescription": "One or more comma-delimited server endpoints for HTTP JSON-RPC connection. If multiple endpoints are given the endpoints are used as fallback in the given order. Also enables the --merge flag. If this flag is omitted and the --eth1-endpoints is supplied, those values will be used. Defaults to http://127.0.0.1:8545.",
       "documentation": "https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#ee-endpoint"
     },
-    "targetPeerCount": {
-      "displayName": "Target Peer Count (set to low number to use less bandwidth)",
+    "maxPeerCount": {
+      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
       "cliConfigPrefix": "--target-peers ",
       "defaultValue": "50",
       "uiControl": {

--- a/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
+++ b/src/common/NodeSpecs/lighthouse/lighthouse-v1.0.0.json
@@ -102,6 +102,15 @@
       },
       "infoDescription": "One or more comma-delimited server endpoints for HTTP JSON-RPC connection. If multiple endpoints are given the endpoints are used as fallback in the given order. Also enables the --merge flag. If this flag is omitted and the --eth1-endpoints is supplied, those values will be used. Defaults to http://127.0.0.1:8545.",
       "documentation": "https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#ee-endpoint"
+    },
+    "targetPeerCount": {
+      "displayName": "Target Peer Count (set to low number to use less bandwidth)",
+      "cliConfigPrefix": "--target-peers ",
+      "defaultValue": "50",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://lighthouse-book.sigmaprime.io/advanced_networking.html#target-peers"
     }
   },
   "category": "L1/ConsensusClient/BeaconNode",

--- a/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
+++ b/src/common/NodeSpecs/lodestar/lodestar-v1.0.0.json
@@ -105,6 +105,14 @@
         "type": "text"
       },
       "infoDescription": "Urls to Eth1 node with enabled rpc. If not explicity provided and execution endpoint provided via execution.urls, it will use execution.urls. Otherwise will try connecting on the specified default(s)"
+    },
+    "maxPeerCount": {
+      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "cliConfigPrefix": "--network.maxPeers ",
+      "defaultValue": "55",
+      "uiControl": {
+        "type": "text"
+      }
     }
   },
   "documentation": {

--- a/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
+++ b/src/common/NodeSpecs/nethermind/nethermind-v1.0.0.json
@@ -153,6 +153,15 @@
       },
       "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/configuration/jsonrpc",
       "infoDescription": "Port number for JSON RPC web sockets calls. By default same port is used as regular HTTP JSON RPC. Ensure the firewall is configured when enabling JSON RPC."
+    },
+    "maxPeerCount": {
+      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "cliConfigPrefix": "--Network.ActivePeersMaxCount ",
+      "defaultValue": "50",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/configuration/network"
     }
   },
   "documentation": {

--- a/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
+++ b/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
@@ -34,7 +34,7 @@
       "uiControl": {
         "type": "filePath"
       },
-      "infoDescription": "Lodestar root directory",
+      "infoDescription": "Nimbus root directory",
       "documentation": "https://nimbus.guide/options.html"
     },
     "http": {

--- a/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
+++ b/src/common/NodeSpecs/nimbus/nimbus-v1.0.0.json
@@ -87,6 +87,14 @@
       },
       "infoDescription": "Urls to Eth1 node with enabled rpc. If not explicity provided and execution endpoint provided via execution.urls, it will use execution.urls. Otherwise will try connecting on the specified default(s)",
       "documentation": "https://nimbus.guide/web3-backup.html?highlight=--web3-url#add-a-backup-web3-provider"
+    },
+    "maxPeerCount": {
+      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "cliConfigPrefix": "--max-peers=",
+      "defaultValue": "160",
+      "uiControl": {
+        "type": "text"
+      }
     }
   },
   "documentation": {

--- a/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
+++ b/src/common/NodeSpecs/prysm/prysm-v1.0.0.json
@@ -9,12 +9,88 @@
     "input": {
       "docker": {
         "containerVolumePath": "/data",
-        "raw": "-p 4000:4000 -p 13000:13000 -p 12000:12000/udp"
+        "raw": "-p 4000:4000 -p 13000:13000 -p 12000:12000/udp",
+        "forcedRawNodeInput": "--accept-terms-of-use=true"
       }
     }
   },
   "category": "L1/ConsensusClient/BeaconNode",
   "rpcTranslation": "eth-l1-beacon",
+  "configTranslation": {
+    "dataDir": {
+      "displayName": "The directory where nimbus will store all blockchain data.",
+      "cliConfigPrefix": "--data-dir=",
+      "uiControl": {
+        "type": "filePath"
+      },
+      "infoDescription": "Prysm root directory",
+      "documentation": "https://docs.prylabs.network/docs/prysm-usage/parameters/"
+    },
+    "httpPort": {
+      "displayName": "The host on which the gateway server runs on",
+      "cliConfigPrefix": "--grpc-gateway-port=",
+      "defaultValue": "3500",
+      "uiControl": {
+        "type": "text"
+      }
+    },
+    "httpCorsDomains": {
+      "displayName": "Comma separated list of domains from which to accept cross origin requests (browser enforced). This flag has no effect if not used with --grpc-gateway-port.",
+      "cliConfigPrefix": "--grpc-gateway-corsdomain=",
+      "uiControl": {
+        "type": "text"
+      }
+    },
+    "httpHostAddress": {
+      "displayName": "The host on which the gateway server runs on",
+      "cliConfigPrefix": "--grpc-gateway-host=",
+      "defaultValue": "127.0.0.1",
+      "uiControl": {
+        "type": "text"
+      }
+    },
+    "httpApis": {
+      "displayName": "Enabled HTTP APIs",
+      "category": "RPC APIs",
+      "cliConfigPrefix": "--http-modules=",
+      "valuesJoinStr": ", ",
+      "uiControl": {
+        "type": "select/multiple",
+        "controlTranslations": [
+          {
+            "value": "Prysm",
+            "config": "prysm"
+          },
+          {
+            "value": "Eth",
+            "config": "eth"
+          }
+        ]
+      },
+      "defaultValue": [
+        "Prysm",
+        "Eth"
+      ],
+      "documentation": "https://docs.nethermind.io/nethermind/ethereum-client/json-rpc"
+    },
+    "eth1ProviderUrl": {
+      "displayName": "One or more Web3 provider URLs used for obtaining deposit contract data.",
+      "cliConfigPrefix": "--http-web3provider=",
+      "defaultValue": "http://localhost:8545",
+      "uiControl": {
+        "type": "text"
+      },
+      "infoDescription": "A mainchain web3 provider string http endpoint. Can contain auth header as well in the format"
+    },
+    "maxPeerCount": {
+      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "cliConfigPrefix": "--p2p-max-peers=",
+      "defaultValue": "45",
+      "uiControl": {
+        "type": "text"
+      }
+    }
+  },
   "documentation": {
     "default": "https://docs.prylabs.network/docs/getting-started",
     "docker": "https://docs.prylabs.network/docs/install/install-with-docker/"

--- a/src/common/NodeSpecs/teku/teku-v1.0.0.json
+++ b/src/common/NodeSpecs/teku/teku-v1.0.0.json
@@ -91,6 +91,15 @@
       },
       "infoDescription": "URL of the execution client's Engine JSON-RPC APIs. This replaces eth1-endpoint after The Merge.",
       "documentation": "https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#ee-endpoint"
+    },
+    "maxPeerCount": {
+      "displayName": "Max Peer Count (set to low number to use less bandwidth)",
+      "cliConfigPrefix": "--p2p-peer-upper-bound=",
+      "defaultValue": "74",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://docs.teku.consensys.net/en/latest/Reference/CLI/CLI-Syntax/#p2p-peer-upper-bound"
     }
   },
   "documentation": {


### PR DESCRIPTION
All of the nodes currently use default settings for max peers, making it difficult for those with limited monthly data caps to run nodes. This change allows users to change the max peers number for each node in the settings.

Config currently doesn't exist for Erigon due to docker compose.

Additionally fixes #44, and separate issue where Besu couldn't switch between the 2 different data storage types.