### PR TITLE
Update geth-v1.0.0.json

### DIFF
--- a/src/common/NodeSpecs/geth/geth-v1.0.0.json
+++ b/src/common/NodeSpecs/geth/geth-v1.0.0.json
@@ -153,6 +153,23 @@
       },
       "defaultValue": "localhost,host.docker.internal"
     },
+    "httpAddress": {
+      "displayName": "HTTP-RPC server listening interface",
+      "cliConfigPrefix": "--http.addr ",
+      "defaultValue": "localhost",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://geth.ethereum.org/docs/rpc/server#http-server"
+    },"httpPort": {
+      "displayName": "HTTP-RPC server listening port",
+      "cliConfigPrefix": "--http.port ",
+      "defaultValue": "8546",
+      "uiControl": {
+        "type": "text"
+      },
+      "documentation": "https://geth.ethereum.org/docs/rpc/server#http-server"
+    },
     "webSocketsPort": {
       "displayName": "WS-RPC server listening port",
       "cliConfigPrefix": "--ws.port ",


### PR DESCRIPTION
The change allows users to set the --http.addr and --http.port flags for Geth if they want to access http-RPC from other hosts/ports