### PR TITLE
[README] Add GitPOAP Badge to Display Number of Minted GitPOAPs for Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ NiceNode’s mission is to simplify running nodes
 <strong>Why is it important for users to run nodes?</strong> Read here https://www.notion.so/nicenode/NiceNode-Home-5c48ccbc50c4416cbca0ce31c037971d
 
 [![Downloads](https://badgen.net/badge/icon/alpha?label=downloads)](https://www.nicenode.xyz/downloads) [![Discord](https://badgen.net/badge/icon/discord?icon=discord&label)](https://discord.gg/k3dpYU4Pn9)
+[![gitpoap badge](https://public-api.gitpoap.io/v1/repo/jgresham/nice-node/badge)](https://www.gitpoap.io/gh/jgresham/nice-node)
 
 ![NiceNodeScreenshot](https://www.nicenode.xyz/img/screenshot.png 'NiceNodeScreenshot')
 


### PR DESCRIPTION
Hey all, this PR adds a [GitPOAP Badge](https://docs.gitpoap.io/api#get-v1repoownernamebadge) to the README that displays the number of minted GitPOAPs for this repository by contributors to this repo.

You can see an example of this in [our Documentation repository](https://github.com/gitpoap/gitpoap-docs#gitpoap-docs).

This should help would-be contributors as well as existing contributors find out that they will/have received GitPOAPs for their contributions.

CC: @colfax23 @kayla-henrie