### PR TITLE
fix: parse log type for nimbus logs

### DIFF
--- a/src/__tests__/node/parseLogMetadata.test.ts
+++ b/src/__tests__/node/parseLogMetadata.test.ts
@@ -5,11 +5,27 @@ describe('Parsing log string testing', () => {
   it('Successfully parses docker log strings with valid timestamps', async () => {
     const logBesu1 =
       '2022-11-12T22:06:50.398994845Z 2022-11-12 22:06:50.398+00:00 | main | INFO  | Besu | Using jemalloc';
-    const logTeku1 =
+    const logTekuInfo1 =
       '2022-11-12T20:36:55.301070423Z 20:36:55.300 INFO  - Local ENR: enr:-Iu4QLmcCCdh2Q8P5_05y2RD1kq1ZafcbKZzZywmPRRkSTIBGZ6XoXgTBWV2FNVhY7AKHgbvkZK2veQchEowqNMLKgIIhGV0aDKQSibFiwIAAAD__________4JpZIJ2NIlzZWNwMjU2azGhAgQdda3wTusVS5M5qesnIV8CsnNq6Nrzgy4I9Ui2spdZ';
+    const logTekuWarn1 =
+      '2022-11-12T20:36:55.301070423Z 20:36:55.300 WARN  - Local ENR: enr:-Iu4QLmcCCdh2Q8P5_05y2RD1kq1ZafcbKZzZywmPRRkSTIBGZ6XoXgTBWV2FNVhY7AKHgbvkZK2veQchEowqNMLKgIIhGV0aDKQSibFiwIAAAD__________4JpZIJ2NIlzZWNwMjU2azGhAgQdda3wTusVS5M5qesnIV8CsnNq6Nrzgy4I9Ui2spdZ';
+    const logTekuError1 =
+      '2022-11-12T20:36:55.301070423Z 20:36:55.300 ERROR  - Local ENR: enr:-Iu4QLmcCCdh2Q8P5_05y2RD1kq1ZafcbKZzZywmPRRkSTIBGZ6XoXgTBWV2FNVhY7AKHgbvkZK2veQchEowqNMLKgIIhGV0aDKQSibFiwIAAAD__________4JpZIJ2NIlzZWNwMjU2azGhAgQdda3wTusVS5M5qesnIV8CsnNq6Nrzgy4I9Ui2spdZ';
+    const logNimbusInfo1 =
+      '2022-11-12T20:36:55.301070423Z 20:36:55.300 INF  - Local ENR: enr:-Iu4QLmcCCdh2Q8P5_05y2RD1kq1ZafcbKZzZywmPRRkSTIBGZ6XoXgTBWV2FNVhY7AKHgbvkZK2veQchEowqNMLKgIIhGV0aDKQSibFiwIAAAD__________4JpZIJ2NIlzZWNwMjU2azGhAgQdda3wTusVS5M5qesnIV8CsnNq6Nrzgy4I9Ui2spdZ';
+    const logNimbusWarn1 =
+      '2022-11-12T20:36:55.301070423Z 20:36:55.300 WRN  - Eth1 chain monitoring failure, restarting topics="eth1"';
+    const logNimbusError1 =
+      '2022-11-12T20:36:55.301070423Z 20:36:55.300 ERR  - Eth1 chain monitoring failure, restarting topics="eth1"';
 
     const metadataBesu1 = parseDockerLogMetadata(logBesu1);
-    const metadataTeku1 = parseDockerLogMetadata(logTeku1);
+    const metadataTekuInfo1 = parseDockerLogMetadata(logTekuInfo1);
+    const metadataTekuWarn1 = parseDockerLogMetadata(logTekuWarn1);
+    const metadataTekuError1 = parseDockerLogMetadata(logTekuError1);
+
+    const metadataNimbusInfo1 = parseDockerLogMetadata(logNimbusInfo1);
+    const metadataNimbusWarn1 = parseDockerLogMetadata(logNimbusWarn1);
+    const metadataNimbusError1 = parseDockerLogMetadata(logNimbusError1);
 
     expect(metadataBesu1).toEqual({
       message:
@@ -17,10 +33,40 @@ describe('Parsing log string testing', () => {
       level: 'INFO',
       timestamp: 1668290810398,
     });
-    expect(metadataTeku1).toEqual({
+    expect(metadataTekuInfo1).toEqual({
       message:
         '20:36:55.300 INFO  - Local ENR: enr:-Iu4QLmcCCdh2Q8P5_05y2RD1kq1ZafcbKZzZywmPRRkSTIBGZ6XoXgTBWV2FNVhY7AKHgbvkZK2veQchEowqNMLKgIIhGV0aDKQSibFiwIAAAD__________4JpZIJ2NIlzZWNwMjU2azGhAgQdda3wTusVS5M5qesnIV8CsnNq6Nrzgy4I9Ui2spdZ',
       level: 'INFO',
+      timestamp: 1668285415301,
+    });
+    expect(metadataTekuWarn1).toEqual({
+      message:
+        '20:36:55.300 WARN  - Local ENR: enr:-Iu4QLmcCCdh2Q8P5_05y2RD1kq1ZafcbKZzZywmPRRkSTIBGZ6XoXgTBWV2FNVhY7AKHgbvkZK2veQchEowqNMLKgIIhGV0aDKQSibFiwIAAAD__________4JpZIJ2NIlzZWNwMjU2azGhAgQdda3wTusVS5M5qesnIV8CsnNq6Nrzgy4I9Ui2spdZ',
+      level: 'WARN',
+      timestamp: 1668285415301,
+    });
+    expect(metadataTekuError1).toEqual({
+      message:
+        '20:36:55.300 ERROR  - Local ENR: enr:-Iu4QLmcCCdh2Q8P5_05y2RD1kq1ZafcbKZzZywmPRRkSTIBGZ6XoXgTBWV2FNVhY7AKHgbvkZK2veQchEowqNMLKgIIhGV0aDKQSibFiwIAAAD__________4JpZIJ2NIlzZWNwMjU2azGhAgQdda3wTusVS5M5qesnIV8CsnNq6Nrzgy4I9Ui2spdZ',
+      level: 'ERROR',
+      timestamp: 1668285415301,
+    });
+    expect(metadataNimbusInfo1).toEqual({
+      message:
+        '20:36:55.300 INF  - Local ENR: enr:-Iu4QLmcCCdh2Q8P5_05y2RD1kq1ZafcbKZzZywmPRRkSTIBGZ6XoXgTBWV2FNVhY7AKHgbvkZK2veQchEowqNMLKgIIhGV0aDKQSibFiwIAAAD__________4JpZIJ2NIlzZWNwMjU2azGhAgQdda3wTusVS5M5qesnIV8CsnNq6Nrzgy4I9Ui2spdZ',
+      level: 'INFO',
+      timestamp: 1668285415301,
+    });
+    expect(metadataNimbusWarn1).toEqual({
+      message:
+        '20:36:55.300 WRN  - Eth1 chain monitoring failure, restarting topics="eth1"',
+      level: 'WARN',
+      timestamp: 1668285415301,
+    });
+    expect(metadataNimbusError1).toEqual({
+      message:
+        '20:36:55.300 ERR  - Eth1 chain monitoring failure, restarting topics="eth1"',
+      level: 'ERROR',
       timestamp: 1668285415301,
     });
   });

--- a/src/main/util/nodeLogUtils.ts
+++ b/src/main/util/nodeLogUtils.ts
@@ -39,11 +39,11 @@ export const parseDockerLogMetadata = (log: string): LogWithMetadata => {
   // handle errors: todo
 
   let level: LogLevel = 'INFO';
-  if (log.includes('ERROR')) {
+  if (log.includes('ERROR') || log.includes('ERR')) {
     level = 'ERROR';
-  } else if (log.includes('WARN')) {
+  } else if (log.includes('WARN') || log.includes('WRN')) {
     level = 'WARN';
-  } else if (log.includes('DEBUG')) {
+  } else if (log.includes('DEBUG') || log.includes('DBG')) {
     level = 'DEBUG';
   }
 


### PR DESCRIPTION
For now, I'd like to fix this. As you suggested @corn-potage, I think a client/node specific implementation is best long-term.